### PR TITLE
Simple query

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/kalm",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "license": "MIT",
   "description": "A client for interacting with the Alert Logic Kalm Public API",
   "author": {

--- a/src/kalm-client.ts
+++ b/src/kalm-client.ts
@@ -39,9 +39,8 @@ class KalmClient {
   async startSimpleQuery(accountID: string, namedQuery: string) {
     const items = await this.alClient.fetch({
       service_name: this.serviceName,
-      account_id: accountID,
       version: this.version,
-      path: `/simple/${namedQuery}`,
+      path: `/query/${accountID}/simple/${namedQuery}`,
     });
     return items as any;
   }


### PR DESCRIPTION
The KALM API has an inconsistent placement of the account ID - so have had to add the account to the URL rather than as a param 